### PR TITLE
Fix KO sliding

### DIFF
--- a/src/game/Enemy.ts
+++ b/src/game/Enemy.ts
@@ -88,6 +88,7 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
         this.play("enemy_idle", true);
       } else {
         this.play("enemy_ko", true);
+        this.setVelocity(0, 0);
       }
     });
 

--- a/src/game/HitBox.ts
+++ b/src/game/HitBox.ts
@@ -69,11 +69,11 @@ export class HitBox extends Phaser.GameObjects.Zone {
 
     /* 2. ── Respuesta si se BLOQUEA ──────────────────────────────── */
     if (blocked) {
-      // - sin daño, stun reducido
-      target.takeDamage(0, guardStun);
-
       // - pequeño retroceso visual
       if (knockBack) target.setVelocityX(knockBack.x * 0.3);
+
+      // - sin daño, stun reducido
+      target.takeDamage(0, guardStun);
 
       // - chispa / sonido opcional  …
       // this.scene.sound.play('block');  etc.
@@ -83,10 +83,14 @@ export class HitBox extends Phaser.GameObjects.Zone {
     }
 
     /* 3. ── Golpe entra con normalidad ───────────────────────────── */
-    target.takeDamage(damage, hitStun);
-
     if (knockBack) {
       target.setVelocity(knockBack.x, knockBack.y);
+    }
+
+    target.takeDamage(damage, hitStun);
+
+    if ((target as any).health === 0) {
+      target.setVelocity(0, 0);
     }
 
     this.destroy();


### PR DESCRIPTION
## Summary
- zero enemy velocity when KO triggers
- apply knockback before damage and stop movement if health hits zero

## Testing
- `npm run build` *(fails: Property 'anims' does not exist on type 'FightScene', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683ff4c0b3f8832eb2c7c82cac4500c3