### PR TITLE
fix attack state reset

### DIFF
--- a/src/game/Enemy.ts
+++ b/src/game/Enemy.ts
@@ -170,6 +170,14 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
       if (hb.active) hb.destroy();
     });
 
+    // Fallback por si la animación se interrumpe
+    this.scene.time.delayedCall(150, () => {
+      if (this.aiState === "attack") {
+        this.aiState = "chase";
+        this.isAttacking = false;
+      }
+    });
+
     this.once(
       Phaser.Animations.Events.ANIMATION_COMPLETE,
       (anim: Phaser.Animations.Animation) => {

--- a/src/game/HitBox.ts
+++ b/src/game/HitBox.ts
@@ -16,9 +16,7 @@ export interface HitData {
   owner: "player" | "enemy";
 }
 
-type DamageableSprite = Phaser.Physics.Arcade.Sprite & {
-  takeDamage(amount: number, stun?: number): void;
-};
+
 
 export class HitBox extends Phaser.GameObjects.Zone {
   public readonly hitData: HitData;

--- a/src/game/Player.ts
+++ b/src/game/Player.ts
@@ -128,6 +128,14 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
       if (hb.active) hb.destroy();
     });
 
+    // Fallback por si la animación se interrumpe
+    this.scene.time.delayedCall(duration, () => {
+      if (this.attackState === "attack") {
+        this.attackState = "idle";
+        this.isAttacking = false;
+      }
+    });
+
     //  ► Cuando termine la animación, volvemos a idle
     this.once(
       Phaser.Animations.Events.ANIMATION_COMPLETE,


### PR DESCRIPTION
## Summary
- ensure attack state resets after hitbox removal
- mirror behaviour for enemy
- remove unused type that broke build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840074d7f58832e8e71013e4475a698