### PR TITLE
Fix player attack flag when taking damage

### DIFF
--- a/src/game/Player.ts
+++ b/src/game/Player.ts
@@ -53,6 +53,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
 
     // ← ① Cancelamos cualquier ataque en curso
     this.attackState = "idle";
+    this.isAttacking = false;
 
     this.scene.time.delayedCall(stun, () => {
       if (this.health > 0) this.play("player_idle", true);


### PR DESCRIPTION
## Summary
- ensure Player exits attacking state when taking damage

## Testing
- `npm run build` *(fails: DamageableSprite unused)*

------
https://chatgpt.com/codex/tasks/task_e_68400739258c832ea6cfe54191eebb31