### PR TITLE
Fix animation-complete registration order

### DIFF
--- a/src/game/Enemy.ts
+++ b/src/game/Enemy.ts
@@ -140,6 +140,22 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
     }
 
     console.log("Animación de ataque:", animKey);
+
+    // Nos aseguramos de capturar el fin de la animación antes de reproducirla
+    this.once(
+      Phaser.Animations.Events.ANIMATION_COMPLETE,
+      (anim: Phaser.Animations.Animation) => {
+        // Si la animación que acaba coincide con la que acabamos de reproducir:
+        if (anim.key === animKey) {
+          this.isAttacking = false;
+          this.scene.time.delayedCall(500, () => {
+            this.attackCooldown = false;
+          });
+          this.aiState = "chase";
+        }
+      }
+    );
+
     // Reproducimos animación de ataque (asegúrate de tenerla creada en createAnimations)
     this.play(animKey, true);
 
@@ -177,20 +193,6 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
         this.isAttacking = false;
       }
     });
-
-    this.once(
-      Phaser.Animations.Events.ANIMATION_COMPLETE,
-      (anim: Phaser.Animations.Animation) => {
-        // Si la animación que acaba coincide con la que acabamos de reproducir:
-        if (anim.key === animKey) {
-          this.isAttacking = false;
-          this.scene.time.delayedCall(500, () => {
-            this.attackCooldown = false;
-          });
-          this.aiState = "chase";
-        }
-      }
-    );
   }
 
   /** Salta y, a mitad de trayecto, crea una hit-box aérea */

--- a/src/game/Player.ts
+++ b/src/game/Player.ts
@@ -85,6 +85,17 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
       this.setVelocityX(0);
     }
 
+    //  ► Cuando termine la animación, volvemos a idle
+    this.once(
+      Phaser.Animations.Events.ANIMATION_COMPLETE,
+      (animation: Phaser.Animations.Animation) => {
+        if (animation.key === anim) {
+          this.attackState = "idle";
+          this.isAttacking = false;
+        }
+      }
+    );
+
     this.anims.play(anim, true);
 
     //  ► Creamos la HitBox con datos mezclados
@@ -136,17 +147,6 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         this.isAttacking = false;
       }
     });
-
-    //  ► Cuando termine la animación, volvemos a idle
-    this.once(
-      Phaser.Animations.Events.ANIMATION_COMPLETE,
-      (animation: Phaser.Animations.Animation) => {
-        if (animation.key === anim) {
-          this.attackState = "idle";
-          this.isAttacking = false;
-        }
-      }
-    );
   }
 
   private tryAttack(): boolean {


### PR DESCRIPTION
## Summary
- attach `ANIMATION_COMPLETE` listeners before playing attack animations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68400abdd530832ea451690b156080e1