### PR TITLE
Fix attack state reset on enemy jump

### DIFF
--- a/src/game/Enemy.ts
+++ b/src/game/Enemy.ts
@@ -226,8 +226,8 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
         airHit
       );
       this.hitGroup.add(hb);
-      this.scene.time.delayedCall(150, () => hb.destroy());
-    });
+    this.scene.time.delayedCall(150, () => hb.destroy());
+  });
 
     /* ── detector de aterrizaje: sólo se ejecuta UNA vez ─────────────────── */
     const landingEvt = this.scene.time.addEvent({
@@ -245,6 +245,14 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
           this.scene.time.delayedCall(1000, () => (this.jumpCooldown = false));
         }
       },
+    });
+
+    // Salvaguarda por si la animación se corta y no aterriza
+    this.scene.time.delayedCall(1000, () => {
+      if (this.isAttacking) {
+        this.isAttacking = false;
+        this.aiState = "chase";
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure enemy jump attack ends even if landing check fails

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68400abd1a24832ea941e261b31ed992