### PR TITLE
Add KO and scene transitions

### DIFF
--- a/src/game/Enemy.ts
+++ b/src/game/Enemy.ts
@@ -26,6 +26,7 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
   /** true mientras esté en anim “guard” o “crouch”                   */
   private isGuarding = false;
   public guardState: "none" | "high" | "low" = "none";
+  private isKO = false;
   constructor(
     scene: Phaser.Scene,
     x: number,
@@ -89,6 +90,7 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
       } else {
         this.play("enemy_ko", true);
         this.setVelocity(0, 0);
+        this.isKO = true;
       }
     });
 
@@ -285,6 +287,7 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
   }
 
   public update(_time: number, _delta: number) {
+    if (this.isKO) return;
     const current = this.anims.currentAnim?.key;
     if (current?.startsWith("enemy_hit") || current === "enemy_ko") return;
 

--- a/src/game/Player.ts
+++ b/src/game/Player.ts
@@ -19,6 +19,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
   public health: number = 100;
   public maxHealth: number = 100;
   public guardState: "none" | "high" | "low" = "none";
+  private isKO = false;
 
   constructor(
     scene: Phaser.Scene,
@@ -63,7 +64,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     if (this.health === 0) {
       this.anims.play("player_ko", true);
       this.setVelocity(0, 0);
-      // aquí podrías deshabilitar controles o disparar "game over"
+      this.isKO = true;
     }
 
     // Emitimos un evento para que la escena actualice el HUD
@@ -199,6 +200,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
   }
 
   public update(_time: number, _delta: number): void {
+    if (this.isKO) return;
     this.guardState = "none";
     // si estamos atacando, no tocar nada hasta que termine
     if (this.attackState === "attack") {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,8 @@ import Phaser from 'phaser';
 import BootScene from './scenes/BootScene';
 import PreloadScene from './scenes/PreloadScene';
 import FightScene from './scenes/FightScene';
+import GameOverScene from './scenes/GameOverScene';
+import VictoryScene from './scenes/VictoryScene';
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -16,7 +18,7 @@ const config: Phaser.Types.Core.GameConfig = {
       debug: false
     }
   },
-  scene: [BootScene, PreloadScene, FightScene]
+  scene: [BootScene, PreloadScene, FightScene, GameOverScene, VictoryScene]
 };
 
 new Phaser.Game(config);

--- a/src/scenes/FightScene.ts
+++ b/src/scenes/FightScene.ts
@@ -16,6 +16,7 @@ export default class FightScene extends Phaser.Scene {
   private enemyHealthBar!: Phaser.GameObjects.Graphics;
   private playerHealthText!: Phaser.GameObjects.Text;
   private enemyHealthText!: Phaser.GameObjects.Text;
+  private ended = false;
 
   // Le decimos a TS que enemy tendrá también health, maxHealth y takeDamage()
 
@@ -288,6 +289,12 @@ export default class FightScene extends Phaser.Scene {
         this.player.maxHealth
       );
       this.playerHealthText.setText(`${hp}`);
+      if (hp <= 0 && !this.ended) {
+        this.ended = true;
+        this.time.delayedCall(2000, () => {
+          this.scene.start('GameOverScene');
+        });
+      }
     });
     this.enemy.on("healthChanged", (hp: number) => {
       this.drawHealthBar(
@@ -298,6 +305,12 @@ export default class FightScene extends Phaser.Scene {
         this.enemy.maxHealth
       );
       this.enemyHealthText.setText(`${hp}`);
+      if (hp <= 0 && !this.ended) {
+        this.ended = true;
+        this.time.delayedCall(2000, () => {
+          this.scene.start('VictoryScene');
+        });
+      }
     });
 
     // 8️⃣ — Teclas de prueba para el enemigo

--- a/src/scenes/GameOverScene.ts
+++ b/src/scenes/GameOverScene.ts
@@ -1,0 +1,17 @@
+import Phaser from 'phaser';
+
+export default class GameOverScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'GameOverScene' });
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor('#222');
+    this.add
+      .text(400, 300, 'Game Over', {
+        color: '#ffffff',
+        fontSize: '16px',
+      })
+      .setOrigin(0.5);
+  }
+}

--- a/src/scenes/PreloadScene.ts
+++ b/src/scenes/PreloadScene.ts
@@ -4,6 +4,14 @@ export default class PreloadScene extends Phaser.Scene {
   constructor() { super({ key: 'PreloadScene' }); }
 
   preload() {
+    this.cameras.main.setBackgroundColor('#333');
+    this.add
+      .text(400, 240, 'Gana el combate para seguir leyendo', {
+        color: '#ffffff',
+        fontSize: '16px',
+      })
+      .setOrigin(0.5);
+
     // barra de progreso
     const bar = this.add.graphics();
     this.load.on('progress', (p: number) => {

--- a/src/scenes/VictoryScene.ts
+++ b/src/scenes/VictoryScene.ts
@@ -1,0 +1,17 @@
+import Phaser from 'phaser';
+
+export default class VictoryScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'VictoryScene' });
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor('#222');
+    this.add
+      .text(400, 300, 'Puedes seguir leyendo', {
+        color: '#ffffff',
+        fontSize: '16px',
+      })
+      .setOrigin(0.5);
+  }
+}


### PR DESCRIPTION
## Summary
- add KO flag for player and enemy
- show KO frame and transition to Game Over or Victory
- display loading message on preload scene
- add dedicated scenes for Game Over and Victory

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840228525b8832e87bdffb497d9cf1f