### PR TITLE
Fix detective kicks spritesheet key

### DIFF
--- a/src/scenes/PreloadScene.ts
+++ b/src/scenes/PreloadScene.ts
@@ -95,7 +95,7 @@ export default class PreloadScene extends Phaser.Scene {
       frameWidth: 48,
       frameHeight: 64,
     });
-    this.load.spritesheet('detective_kick_strong', 'assets/detective/detective_kicks_tight.png', {
+    this.load.spritesheet('detective_kicks_tight', 'assets/detective/detective_kicks_tight.png', {
       frameWidth: 48,
       frameHeight: 64,
     });


### PR DESCRIPTION
## Summary
- correct the spritesheet key for detective strong kick in the preload scene

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684027576710832e82e8ffb916414981