### PR TITLE
Add crouch handling and harder enemy

### DIFF
--- a/src/game/HitBox.ts
+++ b/src/game/HitBox.ts
@@ -50,9 +50,16 @@ export class HitBox extends Phaser.GameObjects.Zone {
     target: Phaser.Physics.Arcade.Sprite & {
       takeDamage: (dmg: number, stun?: number) => void;
       guardState?: "none" | "high" | "low";
+      isCrouching?: boolean;
     }
   ) {
     const { damage, knockBack, hitStun, guardStun, height } = this.hitData;
+
+    const crouching = !!(target as any).isCrouching;
+    if (crouching && height !== "low") {
+      this.destroy();
+      return;
+    }
 
     /* 1. ── ¿El objetivo está guardando? ─────────────────────────── */
     let blocked = false;


### PR DESCRIPTION
## Summary
- ignore high attacks against crouching targets
- let player track guarding and crouching states
- let enemy crouch while guarding or dodging
- boost enemy speed and damage for higher difficulty

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68480469dd20832e9ddf898bd55a72df