### PR TITLE
Add Bison-like difficulty

### DIFF
--- a/src/game/Enemy.ts
+++ b/src/game/Enemy.ts
@@ -6,7 +6,7 @@ import type { HitData } from "./HitBox";
 import { requestEnemyAction, type EnemyDecision } from "./EnemyAI";
 
 export class Enemy extends Phaser.Physics.Arcade.Sprite {
-  private speed = 100; // por si luego quieres movimiento
+  private speed = 200; // estilo M. Bison, mucho más rápido
   public health: number;
   public maxHealth: number;
 
@@ -27,9 +27,18 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
   /** true mientras esté en anim “guard” o “crouch”                   */
   private isGuarding = false;
   public guardState: "none" | "high" | "low" = "none";
+  public isCrouching = false;
   private isKO = false;
   private pendingDecision: EnemyDecision | null = null;
   private lastDecisionTime = 0;
+  private damageMultiplier = 2;
+  private attackChance = 50;
+  private jumpChance = 15;
+  private pattern: "aggressive" | "defensive" | "balanced" | "bison" = "balanced";
+  private patternWeakness: "high" | "low" | null = null;
+  private intelligence = 3; // IA aún más rápida (Bison)
+  private decisionInterval = 1000;
+  private nextPatternSwitch = 0;
   constructor(
     scene: Phaser.Scene,
     x: number,
@@ -65,10 +74,58 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
       // Si no viene grupo, creamos uno vacío (no recomendado; mejor siempre pasarlo desde la escena)
       this.hitGroup = scene.physics.add.group({ runChildUpdate: true });
     }
+
+    this.decisionInterval = 1000 / this.intelligence;
+    this.choosePattern();
   }
 
   public setTarget(target: Phaser.Physics.Arcade.Sprite) {
     this.target = target;
+  }
+
+  private choosePattern() {
+    // Bison tiene un peso mayor en la selección de patrones
+    const rnd = Phaser.Math.Between(0, 100);
+    if (rnd < 80) {
+      this.pattern = "bison";
+    } else {
+      const options = ["aggressive", "defensive", "balanced"] as const;
+      this.pattern = options[Phaser.Math.Between(0, options.length - 1)];
+    }
+    switch (this.pattern) {
+      case "aggressive":
+        this.guardChance = 25;
+        this.attackChance = 80;
+        this.jumpChance = 40;
+        this.patternWeakness = "high";
+        break;
+      case "defensive":
+        this.guardChance = 90;
+        this.attackChance = 30;
+        this.jumpChance = 10;
+        this.patternWeakness = "low";
+        break;
+      case "bison":
+        // Patrón inspirado en M. Bison: presión constante y gran defensa
+        this.guardChance = 95;
+        this.attackChance = 95;
+        this.jumpChance = 60;
+        this.patternWeakness = "low";
+        break;
+      default:
+        this.guardChance = 60;
+        this.attackChance = 50;
+        this.jumpChance = 20;
+        this.patternWeakness = null;
+        break;
+    }
+
+    // escalar por inteligencia y limitar al 100%
+    this.guardChance = Math.min(100, Math.round(this.guardChance * this.intelligence));
+    this.attackChance = Math.min(100, Math.round(this.attackChance * this.intelligence));
+    this.jumpChance = Math.min(100, Math.round(this.jumpChance * this.intelligence));
+
+    this.nextPatternSwitch = this.scene.time.now + Phaser.Math.Between(4000, 7000);
   }
 
   /** Lógica de daño y hit-stun */
@@ -99,6 +156,8 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
 
     this.emit("healthChanged", this.health);
     this.guardState = "none";
+    this.isGuarding = false;
+    this.isCrouching = false;
   }
 
   /** ========================================
@@ -166,8 +225,12 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
 
     // ↓ Creamos la HitBox justo delante del enemigo ↓
     const dir = this.flipX ? -1 : 1;
+    let baseDamage = 10;
+    if (tipoSeleccionado === "punch") baseDamage = 8;
+    if (tipoSeleccionado === "kick_tight") baseDamage = 14;
+
     const defaultHit: HitData = {
-      damage: 10,
+      damage: Math.round(baseDamage * this.damageMultiplier),
       knockBack: new Phaser.Math.Vector2(dir * 50, -100),
       hitStun: 200,
       guardStun: 8,
@@ -217,7 +280,7 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
     /* hit-box en el aire --------------------------------------------------- */
     this.scene.time.delayedCall(300, () => {
       const airHit: HitData = {
-        damage: 12,
+        damage: Math.round(12 * this.damageMultiplier),
         knockBack: new Phaser.Math.Vector2(dir * 60, 100),
         hitStun: 260,
         guardStun: 10,
@@ -291,6 +354,8 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
 
   public update(_time: number, _delta: number) {
     if (this.isKO) return;
+    // no reiniciamos isCrouching aquí para que los hitboxes puedan detectar
+    // correctamente si el enemigo sigue agachado durante este frame
     const current = this.anims.currentAnim?.key;
     if (current?.startsWith("enemy_hit") || current === "enemy_ko") return;
 
@@ -306,16 +371,23 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
     const dist = Math.abs(dx);
     const dir = Math.sign(dx);
 
+    if (_time > this.nextPatternSwitch) {
+      this.choosePattern();
+    }
+
     // Periodically query OpenAI for a suggested action
-    if (_time - this.lastDecisionTime > 1000 && !this.pendingDecision) {
+    if (_time - this.lastDecisionTime > this.decisionInterval && !this.pendingDecision) {
       this.lastDecisionTime = _time;
       requestEnemyAction({ distance: dist }).then((act) => {
         if (act) this.pendingDecision = act;
       });
     }
 
-    // Orientación hacia el jugador cada frame, sin afectar animaciones
-    this.setFlipX(dx < 0);
+    // Orientación hacia el jugador cada frame, pero evita girar en mitad de un
+    // ataque o de una guardia para que no se corten las animaciones
+    if (!this.isAttacking && !this.isGuarding) {
+      this.setFlipX(dx < 0);
+    }
 
     const incoming = this.getIncomingHitHeight();
     if (
@@ -325,7 +397,10 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
       !this.isGuarding
     ) {
       console.log("Decido cubrir", incoming);
-      if (Phaser.Math.Between(0, 100) < this.guardChance) {
+      const shouldGuard =
+        Phaser.Math.Between(0, 100) < this.guardChance &&
+        incoming !== this.patternWeakness;
+      if (shouldGuard) {
         // decidimos cubrir
         this.isGuarding = true;
         body.setVelocityX(0);
@@ -333,6 +408,7 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
         if (incoming === "low") {
           this.play("enemy_guard_low", true);
           this.guardState = "low";
+          this.isCrouching = true;
         } else {
           this.play("enemy_guard_high", true);
           this.guardState = "high";
@@ -342,6 +418,7 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
         this.scene.time.delayedCall(300, () => {
           this.isGuarding = false;
           this.guardState = "none";
+          this.isCrouching = false;
           this.play("enemy_idle", true);
         });
         return; // nada más este frame
@@ -349,12 +426,14 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
         // si no va a cubrir pero es alto…
         // …agáchate para esquivar
         this.isGuarding = true;
+        this.isCrouching = true;
         body.setVelocityX(0);
         this.play("enemy_down", true); // usa tu anim. de agacharse
 
         this.scene.time.delayedCall(300, () => {
           this.isGuarding = false;
           this.guardState = "none";
+          this.isCrouching = false;
           this.play("enemy_idle", true);
         });
         return;
@@ -395,13 +474,17 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
           ) {
             this.startJumpAttack();
           }
-        } else if (dist <= this.groundAttackRange && body.blocked.down) {
+        } else if (
+          dist <= this.groundAttackRange &&
+          body.blocked.down &&
+          Phaser.Math.Between(0, 100) < this.attackChance
+        ) {
           body.setVelocityX(0);
           this.aiState = "attack";
         } else if (
           dist < this.airAttackRange &&
           !this.jumpCooldown &&
-          Phaser.Math.Between(0, 100) < 15
+          Phaser.Math.Between(0, 100) < this.jumpChance
         ) {
           this.startJumpAttack();
         }

--- a/src/game/EnemyAI.ts
+++ b/src/game/EnemyAI.ts
@@ -33,7 +33,7 @@ export async function requestEnemyAction(
           {
             role: 'system',
             content:
-              'You are an AI for a simple fighting game. Respond with one word: "chase", "attack" or "jump".',
+              'You control a ruthless boss inspired by M. Bison from the European release of Street Fighter 2. Respond with a single word: "chase", "attack" or "jump" to overwhelm the player while minimizing damage.',
           },
           {
             role: 'user',

--- a/src/game/HitBox.ts
+++ b/src/game/HitBox.ts
@@ -50,9 +50,16 @@ export class HitBox extends Phaser.GameObjects.Zone {
     target: Phaser.Physics.Arcade.Sprite & {
       takeDamage: (dmg: number, stun?: number) => void;
       guardState?: "none" | "high" | "low";
+      isCrouching?: boolean;
     }
   ) {
     const { damage, knockBack, hitStun, guardStun, height } = this.hitData;
+
+    const crouching = !!(target as any).isCrouching;
+    if (crouching && height !== "low") {
+      this.destroy();
+      return;
+    }
 
     /* 1. ── ¿El objetivo está guardando? ─────────────────────────── */
     let blocked = false;

--- a/src/game/Player.ts
+++ b/src/game/Player.ts
@@ -19,6 +19,9 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
   public health: number = 100;
   public maxHealth: number = 100;
   public guardState: "none" | "high" | "low" = "none";
+  public isGuarding = false;
+  public isCrouching = false;
+  private damageMultiplier = 0.5; // daño reducido
   private isKO = false;
 
   constructor(
@@ -51,6 +54,10 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     if (amount <= 0) return;
     this.health = Phaser.Math.Clamp(this.health - amount, 0, this.maxHealth);
     this.anims.play("player_damage", true);
+
+    this.isGuarding = false;
+    this.guardState = "none";
+    this.isCrouching = false;
 
     // ← ① Cancelamos cualquier ataque en curso
     this.attackState = "idle";
@@ -116,13 +123,16 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
 
     const yOffset = inAir ? -32 /* más alto */ : -16; /* suelo */
 
+    const finalHit = { ...defaultHit, ...hitData } as HitData;
+    finalHit.damage = Math.round(finalHit.damage * this.damageMultiplier);
+
     const hb = new HitBox(
       this.scene,
       this.x + dir * 24,
       this.y - yOffset,
       hitboxWidth,
       24,
-      { ...defaultHit, ...hitData }
+      finalHit
     );
     // hb.setFillStyle(0xff0000, 0.3); // semitransparente (removed, not available on HitBox)
     hb.setDepth(10);
@@ -201,14 +211,18 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
 
   public update(_time: number, _delta: number): void {
     if (this.isKO) return;
-    this.guardState = "none";
-    // si estamos atacando, no tocar nada hasta que termine
+
+    const body = this.body as Phaser.Physics.Arcade.Body;
+
+    // El estado de guardia/crouch se actualizará más abajo según la entrada
+    // para evitar ventanas en las que la detección de golpes no refleje la
+    // postura real del jugador.
+
     if (this.attackState === "attack") {
       return;
     }
-    // Ataque cancela todo lo demás
+
     if (this.tryAttack()) return;
-    const body = this.body as Phaser.Physics.Arcade.Body;
 
     /* 0 ── ORIENTACIÓN HACIA EL ENEMIGO ─────────────────────────── */
     const enemy = (this.scene as any).enemy;
@@ -243,16 +257,19 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
       return;
     }
 
-    /* 4 ── GUARDIA ALTA (atrás + enemigo atacando) ──────────────── */
+    /* 4 ── GUARDIA (atrás + enemigo atacando) ───────────────────── */
     const enemyIsAttacking = enemy?.isAttacking;
     if (backPressed && enemyIsAttacking) {
       this.setVelocityX(0);
+      this.isGuarding = true;
 
       if (down) {
-        this.guardState = "low"; // guardia baja
+        this.guardState = "low";
+        this.isCrouching = true;
         this.anims.play("player_guard_low", true);
       } else {
-        this.guardState = "high"; // guardia alta
+        this.guardState = "high";
+        this.isCrouching = false;
         this.anims.play("player_guard_high", true);
       }
 
@@ -276,12 +293,18 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
     /* 6 ── AGACHARSE (↓ o ↓+atrás sin ataque rival) ─────────────── */
     if (down) {
       this.setVelocityX(0);
+      this.isCrouching = true;
+      this.isGuarding = false;
+      this.guardState = "none";
       this.anims.play("player_down", true);
       return;
     }
 
     /* 7 ── IDLE ─────────────────────────────────────────────────── */
     this.setVelocityX(0);
+    this.isCrouching = false;
+    this.isGuarding = false;
+    this.guardState = "none";
     this.anims.play("player_idle", true);
   }
 }


### PR DESCRIPTION
## Summary
- crank up enemy speed, damage and decision rate
- bias pattern selection toward a new "bison" mode with strong offense
- update ChatGPT prompt to describe a ruthless boss
- preserve crouch and guard state through the frame
- don't reset enemy crouch flag automatically

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68480469dd20832e9ddf898bd55a72df