### PR TITLE
Return default action when OpenAI key missing

### DIFF
--- a/src/game/EnemyAI.ts
+++ b/src/game/EnemyAI.ts
@@ -4,9 +4,12 @@ export type EnemyDecision = 'chase' | 'attack' | 'jump';
 declare const process: { env?: Record<string, string | undefined> } | undefined;
 
 /**
- * Queries OpenAI for the next enemy action. Returns `null` if the request fails
- * or no valid action is found. The function expects an API key in the
- * `OPENAI_API_KEY` environment variable.
+ * Queries OpenAI for the next enemy action.
+ *
+ * If `OPENAI_API_KEY` is not configured, the function logs a warning and
+ * immediately returns `'chase'` as a sensible default. When the key is
+ * configured, `null` is returned only if the request fails or no valid action
+ * is found.
  */
 export async function requestEnemyAction(
   context: { distance: number }
@@ -14,7 +17,7 @@ export async function requestEnemyAction(
   const apiKey = process?.env?.OPENAI_API_KEY;
   if (!apiKey) {
     console.warn('OPENAI_API_KEY not configured');
-    return null;
+    return 'chase';
   }
 
   const controller = new AbortController();


### PR DESCRIPTION
## Summary
- update EnemyAI docs
- default to 'chase' when `OPENAI_API_KEY` is not configured

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684816512768832e8a82aa5a92f81188