### PR TITLE
Improve hit effects

### DIFF
--- a/src/game/Enemy.ts
+++ b/src/game/Enemy.ts
@@ -222,6 +222,7 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
 
     // Reproducimos animación de ataque (asegúrate de tenerla creada en createAnimations)
     this.play(animKey, true);
+    const animDuration = this.anims.get(animKey)?.duration ?? 150;
 
     // ↓ Creamos la HitBox justo delante del enemigo ↓
     const dir = this.flipX ? -1 : 1;
@@ -236,6 +237,7 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
       guardStun: 8,
       height: "mid",
       owner: "enemy",
+      type: tipoSeleccionado === "punch" ? "punch" : "kick",
     };
 
     const hb = new HitBox(
@@ -249,13 +251,13 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
     hb.setDepth(10);
     this.hitGroup.add(hb);
 
-    // Destruimos la HitBox tras 150 ms si aún existe
-    this.scene.time.delayedCall(150, () => {
+    // Destruimos la HitBox al terminar la animación
+    this.scene.time.delayedCall(animDuration, () => {
       if (hb.active) hb.destroy();
     });
 
     // Fallback por si la animación se interrumpe
-    this.scene.time.delayedCall(150, () => {
+    this.scene.time.delayedCall(animDuration + 50, () => {
       if (this.aiState === "attack") {
         this.aiState = "chase";
         this.isAttacking = false;
@@ -287,6 +289,7 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
         guardStun: 10,
         height: "mid",
         owner: "enemy",
+        type: "kick",
       };
       const hb = new HitBox(
         this.scene,
@@ -536,9 +539,9 @@ export class Enemy extends Phaser.Physics.Arcade.Sprite {
       key: "enemy_punch",
       frames: anims.generateFrameNumbers("detective_punch_right", {
         start: 0,
-        end: 0,
+        end: 1,
       }),
-      frameRate: 10,
+      frameRate: 6,
       repeat: 0,
     });
 

--- a/src/game/HitBox.ts
+++ b/src/game/HitBox.ts
@@ -14,6 +14,8 @@ export interface HitData {
   height: "high" | "mid" | "low";
   /** Quién lanzó el golpe (player | enemy) */
   owner: "player" | "enemy";
+  /** Tipo de ataque: punch o kick (opcional) */
+  type?: "punch" | "kick";
 }
 
 
@@ -89,7 +91,8 @@ export class HitBox extends Phaser.GameObjects.Zone {
     }
 
     const finalDamage = height === "high" ? Math.round(damage * 0.5) : damage;
-    target.takeDamage(finalDamage, hitStun);
+    const extraStun = height === "high" ? 80 : 0;
+    target.takeDamage(finalDamage, hitStun + extraStun);
     
     if ((target as any).health === 0) {
       target.setVelocity(0, 0);

--- a/src/game/Player.ts
+++ b/src/game/Player.ts
@@ -173,6 +173,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         damage: 6,
         hitStun: 120,
         knockBack: new Phaser.Math.Vector2(dir * 40, 0),
+        type: "punch",
       });
       return true;
     }
@@ -182,6 +183,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
         damage: 10,
         hitStun: 180,
         knockBack: new Phaser.Math.Vector2(dir * 40, 0),
+        type: "kick",
       });
       return true;
     }
@@ -194,6 +196,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
           knockBack: new Phaser.Math.Vector2(dir * 10, -200),
           hitStun: 300,
           height: "mid",
+          type: "kick",
         });
         return true;
       } else {
@@ -202,6 +205,7 @@ export class Player extends Phaser.Physics.Arcade.Sprite {
           damage: 14,
           knockBack: new Phaser.Math.Vector2(dir * 30, 0),
           hitStun: 260,
+          type: "kick",
         });
         return true;
       }

--- a/src/scenes/FightScene.ts
+++ b/src/scenes/FightScene.ts
@@ -78,26 +78,6 @@ export default class FightScene extends Phaser.Scene {
 
     this.physics.add.collider(this.enemy, platforms);
 
-    this.enemy.onHit(() => {
-      // Aquí pones la reacción extra al impactar:
-      // — Sonido de golpe —
-      this.sound.play('hit_sound');
-
-      // — Partículas de efecto —
-      /* const p = this.add.particles("sangre");
-  p.createEmitter({
-    x: this.player.x,
-    y: this.player.y - 20,
-    speed: { min: -100, max: 100 },
-    lifespan: 300,
-    quantity: 5,
-    scale: { start: 1, end: 0 },
-    blendMode: "ADD"
-  }).explode(10, this.player.x, this.player.y - 20); */
-
-      // — Cámara tiembla un poquito —
-      this.cameras.main.shake(100, 0.01);
-    });
 
     this.time.addEvent({
       delay: 500, // esperar medio segundo tras crear enemy
@@ -130,6 +110,7 @@ export default class FightScene extends Phaser.Scene {
 
       if (hit.hitData.owner !== "player") return; // ← filtro
       hit.applyTo(enem);
+      this.playHitEffects(hit);
     });
 
     // 7️⃣ — Overlap: cualquier HitBox del grupo golpea al jugador
@@ -139,7 +120,7 @@ export default class FightScene extends Phaser.Scene {
 
       if (hit.hitData.owner !== "enemy") return;
       hit.applyTo(plyr);
-      this.enemy.triggerHit();
+      this.playHitEffects(hit);
     });
 
     // 7️⃣ — HUD de vida
@@ -270,6 +251,14 @@ export default class FightScene extends Phaser.Scene {
     (this.enemy as Enemy).update(time, delta);
   }
 
+  private playHitEffects(hit: HitBox) {
+    this.sound.play('hit_sound');
+    const { type, height } = hit.hitData as any;
+    if (type === 'kick' || (type === 'punch' && height === 'high')) {
+      this.cameras.main.shake(100, 0.01);
+    }
+  }
+
   private createPlayerAnimations(): void {
     this.anims.create({
       key: "player_idle",
@@ -325,10 +314,6 @@ export default class FightScene extends Phaser.Scene {
       frameRate: 8,
       repeat: 0,
     });
-    console.log(
-      "Player punch animation exists?",
-      this.anims.exists("player_punch")
-    );
     this.anims.create({
       key: "player_kick_light",
       frames: this.anims.generateFrameNumbers("player_kick_soft", {


### PR DESCRIPTION
## Summary
- extend stun duration when hit height is high
- give enemy punch a second frame and slower rate
- destroy enemy hitboxes when its attack animation ends

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848216c90a4832e92a4547bb07a849d