### PR TITLE
Remove broken logo asset from BootScene

### DIFF
--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -5,7 +5,6 @@ export default class BootScene extends Phaser.Scene {
 
   preload() {
     // aquí puedes cargar imágenes pequeñas de carga
-    this.load.image('logo', 'assets/logo.png');
   }
 
   create() {


### PR DESCRIPTION
## Summary
- clean BootScene preload step
- ensure PreloadScene still loads

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684863c2d19c832eb76b92f04da26567